### PR TITLE
fix default liners value for parsing options through hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vimrc
+*.pyc
+pylama.egg-info/*
 dist
 docs/_build

--- a/pylama/config.py
+++ b/pylama/config.py
@@ -30,7 +30,7 @@ def parse_options(
         async=_Default(async), format=_Default('pep8'),
         select=_Default(select), ignore=_Default(ignore),
         report=_Default(None), verbose=_Default(False),
-        linters=_Default(linters), complexity=_Default(complexity),
+        linters=_Default(','.join(linters)), complexity=_Default(complexity),
         options=_Default(options))
 
     if not (args is None):


### PR DESCRIPTION
I've just encountered strange errors.

I've added pylama to one of my project,added pylama.ini, and defined format and skip in main secton only.

This gave me this error while trying to commit:

``` python
Traceback (most recent call last):
  File ".git/hooks/pre-commit", line 6, in <module>
    sys.exit(git_hook())
  File "/home/fizyk/.virtualenvs/zlota/local/lib/python2.7/site-packages/pylama-1.5.3-py2.7.egg/pylama/hook.py", line 36, in git_hook
    options = parse_options()
  File "/home/fizyk/.virtualenvs/zlota/local/lib/python2.7/site-packages/pylama-1.5.3-py2.7.egg/pylama/config.py", line 62, in parse_options
    value.value = action.type(value.value)
  File "/home/fizyk/.virtualenvs/zlota/local/lib/python2.7/site-packages/pylama-1.5.3-py2.7.egg/pylama/config.py", line 96, in <lambda>
    set(i for i in s.strip().split(',') if i))
AttributeError: 'tuple' object has no attribute 'strip'
```

This fix addresses this issue.
