### PR TITLE
Intify opts numbers

### DIFF
--- a/pylama/libs/inirama.py
+++ b/pylama/libs/inirama.py
@@ -193,7 +193,10 @@ class Section(MutableMapping):
         self.__storage__ = dict()
 
     def __setitem__(self, name, value):
-        self.__storage__[name] = str(value)
+        value = str(value)
+        if value.isdigit():
+            value = int(value)
+        self.__storage__[name] = value
 
     def __getitem__(self, name):
         return self.__storage__[name]


### PR DESCRIPTION
This change changes number to integers within options, so whenever linter expects to work on int, not a string, it won't break it's behaviour
