### PR TITLE
Copy options lists

### DIFF
--- a/pylama/core.py
+++ b/pylama/core.py
@@ -111,8 +111,8 @@ def prepare_params(modeline, fileconfig, options):
     """
     params = dict(skip=False, ignore=[], select=[])
     if options:
-        params['ignore'] = options.ignore
-        params['select'] = options.select
+        params['ignore'] = options.ignore[:]
+        params['select'] = options.select[:]
 
     for config in filter(None, [modeline, fileconfig]):
         for key in ('ignore', 'select'):


### PR DESCRIPTION
We need to copy `ignore` and `select` lists to keep overiding them per file. Otherwise errors ignored per file will be added to global `options` object after each file.