### PR TITLE
allow the setting of linters for specific files

### DIFF
--- a/pylama/core.py
+++ b/pylama/core.py
@@ -43,7 +43,7 @@ def run(path='', code=None, rootdir=CURDIR, options=None):
             if params.get('skip'):
                 return errors
 
-            for item in linters:
+            for item in params.get('linters') or linters:
 
                 if not isinstance(item, tuple):
                     item = (item, LINTERS.get(item))
@@ -109,13 +109,13 @@ def prepare_params(modeline, fileconfig, options):
     :return dict:
 
     """
-    params = dict(skip=False, ignore=[], select=[])
+    params = dict(skip=False, ignore=[], select=[], linters=[])
     if options:
         params['ignore'] = options.ignore[:]
         params['select'] = options.select[:]
 
     for config in filter(None, [modeline, fileconfig]):
-        for key in ('ignore', 'select'):
+        for key in ('ignore', 'select', 'linters'):
             params[key] += process_value(key, config.get(key, []))
         params['skip'] = bool(int(config.get('skip', False)))
 

--- a/tests.py
+++ b/tests.py
@@ -37,7 +37,7 @@ def test_prepare_params():
     options = parse_options(ignore=['D'], config=False)
     params = prepare_params(p1, p2, options)
     assert params == {
-        'ignore': set(['R45', 'E34', 'W', 'D']), 'select': set(['R01', 'E']), 'skip': False}
+        'ignore': set(['R45', 'E34', 'W', 'D']), 'select': set(['R01', 'E']), 'skip': False, 'linters': []}
 
 
 def test_checkpath():


### PR DESCRIPTION
Allows to set linters for specific files, e.g.:

`[pylama:dummy.py]`
`linters = pep8,pyflakes`

`[pylama:*js]`
`linters = gjslint`