### PR TITLE
Use auto-force if a single file argument is being passed

### DIFF
--- a/pylama/main.py
+++ b/pylama/main.py
@@ -35,7 +35,9 @@ def check_path(options, rootdir=None, candidates=None):
     paths = []
     for path in candidates:
 
-        if not options.force and not any(l.allow(path) for _, l in options.linters): # noqa
+        if (not options.force and
+                not len(candidates) == 1 and
+                not any(l.allow(path) for _, l in options.linters)):
             continue
 
         if not op.exists(path):


### PR DESCRIPTION
This allows checking files that do not end in `.py`, but are Python
files, e.g. through a shebang line.

Additionally or instead the `allow` function could look for a shebang line like `#!/usr/bin/env python`, but would then have to open the file, which is bad when running it against a directory.

I think that passing a single path to a file should automatically check it.