### PR TITLE
Return all errors even if a linter returns `None`

### DIFF
--- a/pylama/core.py
+++ b/pylama/core.py
@@ -60,10 +60,12 @@ def run(path='', code=None, rootdir=CURDIR, options=None):
                 lparams = linters_params.get(lname, dict())
                 LOGGER.info("Run %s %s", lname, lparams)
 
-                for er in linter.run(
+                linter_errors = linter.run(
                         path, code=code, ignore=params.get("ignore", set()),
-                        select=params.get("select", set()), params=lparams):
-                    errors.append(Error(filename=path, linter=lname, **er))
+                        select=params.get("select", set()), params=lparams)
+                if linter_errors:
+                    for er in linter_errors:
+                        errors.append(Error(filename=path, linter=lname, **er))
 
     except IOError as e:
         LOGGER.debug("IOError %s", e)


### PR DESCRIPTION
If a linter returns `None` instead of a iterable (latest isort version, fix pr: https://github.com/timothycrosley/isort/pull/362) an exceptions is raised. This can intermittently cause (depending on the random order of the linters) pylama to not return any errors at all, thus `passing` the project.