### PR TITLE
[WIP] setup.py: install_requires: remove versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ _project = re.search(r'^__project__\s*=\s*"(.*)"', _meta, re.M).group(1)
 _version = re.search(r'^__version__\s*=\s*"(.*)"', _meta, re.M).group(1)
 
 install_requires = [
-    l for l in _read('requirements.txt').split('\n')
+    l.split()[0] for l in _read('requirements.txt').split('\n')
     if l and not l.startswith('#') and not l.startswith('-')]
 if sys.version_info < (2, 7):
     install_requires += ['argparse']

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ _project = re.search(r'^__project__\s*=\s*"(.*)"', _meta, re.M).group(1)
 _version = re.search(r'^__version__\s*=\s*"(.*)"', _meta, re.M).group(1)
 
 install_requires = [
-    l.split()[0] for l in _read('requirements.txt').split('\n')
+    l.replace('==', '>=') for l in _read('requirements.txt').split('\n')
     if l and not l.startswith('#') and not l.startswith('-')]
 if sys.version_info < (2, 7):
     install_requires += ['argparse']


### PR DESCRIPTION
I am trying to install pylama system-wide on Arch Linux, which has
pyflakes 1.1.0 already, and running pylama fails with:

> pkg_resources.ContextualVersionConflict: (pyflakes 1.1.0
> (/usr/lib/python3.5/site-packages),
> Requirement.parse('pyflakes==1.0.0'), {'pylama'})

> pkg_resources.DistributionNotFound: The 'pyflakes==1.0.0' distribution
> was not found and is required by pylama

This commit fixes it by only using the package name from
requirements.txt, but not the version.

Alternatively I could imagine replacing the '==' with '>=' to ensure the
minimum requirements are met, which is probably better?!

On the other hand this might not be useful altogether, and instead tools
like pipsi or virtualenvs should be used for pylama only?!