### PR TITLE
TBD: Add new "parsable" output format

### DIFF
--- a/pylama/config.py
+++ b/pylama/config.py
@@ -81,8 +81,9 @@ PARSER.add_argument('--version', action='version',
                     version='%(prog)s ' + __version__)
 
 PARSER.add_argument(
-    "--format", "-f", default=_Default('pep8'), choices=['pep8', 'pylint'],
-    help="Choose errors format (pep8, pylint).")
+    "--format", "-f", default=_Default('pep8'),
+    choices=['pep8', 'pylint', 'parsable'],
+    help="Choose errors format (pep8, pylint, parsable).")
 
 PARSER.add_argument(
     "--select", "-s", default=_Default(''), type=split_csp_str,

--- a/pylama/main.py
+++ b/pylama/main.py
@@ -81,9 +81,12 @@ def process_paths(options, candidates=None, error=True):
     """Process files and log errors."""
     errors = check_path(options, rootdir=CURDIR, candidates=candidates)
 
-    pattern = "%(filename)s:%(lnum)s:%(col)s: %(text)s"
-    if options.format == 'pylint':
+    if options.format == 'pep8':
+        pattern = "%(filename)s:%(lnum)s:%(col)s: %(text)s"
+    elif options.format == 'pylint':
         pattern = "%(filename)s:%(lnum)s: [%(type)s] %(text)s"
+    else:  # 'parsable'
+        pattern = "%(filename)s:%(lnum)s:%(col)s: [%(type)s] %(text)s"
 
     for er in errors:
         if options.abspath:


### PR DESCRIPTION
This is meant to provide all information that is available.

It does not include "number", which currently is just the first word
from "msg" itself.

TODO:
 - [ ] It does not include the "number" info, which is currently just the first word of the message.
What do you think about splitting this, and to have number and message separate?
This would be especially useful when allowing custom output formats.

Ref: https://github.com/klen/pylama/issues/73