### PR TITLE
Fix SyntaxError handling

### DIFF
--- a/pylama/core.py
+++ b/pylama/core.py
@@ -73,7 +73,8 @@ def run(path='', code=None, rootdir=CURDIR, options=None):
     except SyntaxError as e:
         LOGGER.debug("SyntaxError %s", e)
         errors.append(
-            Error(linter=lname, lnum=e.lineno, col=e.offset, text=e.args[0],
+            Error(linter='pylama', lnum=e.lineno, col=e.offset,
+                  text='E0100 SyntaxError: {}'.format(e.args[0]),
                   filename=path))
 
     except Exception as e: # noqa

--- a/pylama/lint/pylama_mccabe.py
+++ b/pylama/lint/pylama_mccabe.py
@@ -15,10 +15,7 @@ class Linter(Abstract):
 
         :return list: List of errors.
         """
-        try:
-            tree = compile(code, path, "exec", ast.PyCF_ONLY_AST)
-        except SyntaxError as exc:
-            return [{'lnum': exc.lineno, 'text': 'Invalid syntax: %s' % exc.text.strip()}]
+        tree = compile(code, path, "exec", ast.PyCF_ONLY_AST)
 
         McCabeChecker.max_complexity = int(params.get('complexity', 10))
         return [


### PR DESCRIPTION
Do not special-case mccabe - it is also not handled in pyflakes.

This uses 'pylama' as the linter name in this case, and also adds an
error number to it for consistency.

Fixes https://github.com/klen/pylama/issues/72.

TODO:
 - [ ] I just made the error number `E0100` up.  Are there some rules for that?!