### PR TITLE
pydocstyle: remove colon after code at start of message

### DIFF
--- a/pylama/lint/pylama_pydocstyle.py
+++ b/pylama/lint/pylama_pydocstyle.py
@@ -15,7 +15,11 @@ class Linter(Abstract):
 
         :return list: List of errors.
         """
-        return [
-            {'lnum': e.line, 'text': e.message, 'type': 'D', 'number': e.code}
-            for e in PEP257Checker().check_source(code, path)
-        ]
+        return [{
+            'lnum': e.line,
+            # Remove colon after error code ("D403: …" => "D403 …").
+            'text': (e.message[0:4] + e.message[5:]
+                     if e.message[4] == ':' else e.message),
+            'type': 'D',
+            'number': e.code
+        } for e in PEP257Checker().check_source(code, path)]


### PR DESCRIPTION
This makes it more consistent with other linters.