### PR TITLE
Fix pylama crash if default config not exists

### DIFF
--- a/pylama/config.py
+++ b/pylama/config.py
@@ -258,6 +258,8 @@ def setup_logger(options):
     if options.report:
         LOGGER.removeHandler(STREAM)
         LOGGER.addHandler(logging.FileHandler(options.report, mode='w'))
-    LOGGER.info('Try to read configuration from: ' + options.options)
+
+    if options.options:
+        LOGGER.info('Try to read configuration from: ' + options.options)
 
 # pylama:ignore=W0212,D210,F0001


### PR DESCRIPTION
After using get_default_config_file() since
caaf7952c36213601d6d3cddd370c533cf6b4e32, options.options could be
None as get_default_config_file() will return nothing if no default
config files are being found.

Hence we need to do None checking in setup_logger()