### PR TITLE
Allow ignore_decorators to pass to pydocstyle.

### DIFF
--- a/pylama/config.py
+++ b/pylama/config.py
@@ -242,7 +242,7 @@ def get_config(ini_path=None, rootdir=None):
     config = Namespace()
     config.default_section = 'pylama'
 
-    if not ini_path:
+    if not ini_path or ini_path == 'None':
         path = get_default_config_file(rootdir)
         if path:
             config.read(path)

--- a/pylama/lint/pylama_pydocstyle.py
+++ b/pylama/lint/pylama_pydocstyle.py
@@ -17,12 +17,16 @@ class Linter(Abstract):
     """Check pydocstyle errors."""
 
     @staticmethod
-    def run(path, code=None, **meta):
+    def run(path, code=None, params=None, **meta):
         """pydocstyle code checking.
 
         :return list: List of errors.
         """
-        check_source_args = (code, path, None) if THIRD_ARG else (code, path)
+        if 'ignore_decorators' in params:
+            ignore_decorators = params['ignore_decorators']
+        else:
+            ignore_decorators = None
+        check_source_args = (code, path, ignore_decorators) if THIRD_ARG else (code, path)
         return [{
             'lnum': e.line,
             # Remove colon after error code ("D403: ..." => "D403 ...").


### PR DESCRIPTION
This will pass parameters to pydocstyle, retrieve ignore_decorators if it exists, and then use it.

There was also a bug with ini_path always having been stringified in my testing, so that is also checked now.