### PR TITLE
Prevent fail when used with pytest and --stric argument.

### DIFF
--- a/pylama/pytest.py
+++ b/pylama/pytest.py
@@ -10,6 +10,14 @@ import pytest
 HISTKEY = "pylama/mtimes"
 
 
+def pytest_load_initial_conftests(early_config, parser, args):
+    # Marks have to be registered before usage
+    # to not fail with --strict command line argument
+    early_config.addinivalue_line(
+        'markers',
+        'pycodestyle: Mark test as using pylama code audit tool.')
+
+
 def pytest_addoption(parser):
     group = parser.getgroup("general")
     group.addoption(


### PR DESCRIPTION
Using `pylama` as `pytest` plugin will fail if `--strict` command line option is used.

According to `pytest` changelog for version 2.2:
> introduce registration for “pytest.mark.*” helpers via ini-files or through plugin hooks. Also introduce a “–strict” option which will treat unregistered markers as errors allowing to avoid typos and maintain a well described set of markers for your test suite. See examples at http://pytest.org/latest/mark.html and its links.

This PR register `pycodestyle` mark used by `pylama` to follow `pytest` strict mode.