### PR TITLE
Fix parsing of multi-options for pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: python
 
-python:
-    - "2.7"
-
-env:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py35
-    - TOXENV=cov
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=cov
+      after_script:
+        - pip install coveralls;
+        - coveralls;
 
 branches:
     only:
@@ -17,9 +22,3 @@ branches:
 install: pip install tox
 
 script: tox
-
-after_script:
-    - if [ $TOXENV == "cov" ]; then
-        pip install coveralls;
-        coveralls;
-      fi

--- a/pylama/lint/pylama_pycodestyle.py
+++ b/pylama/lint/pylama_pycodestyle.py
@@ -1,5 +1,5 @@
 """pycodestyle support."""
-from pycodestyle import BaseReport, StyleGuide, get_parser
+from pycodestyle import BaseReport, StyleGuide, get_parser, _parse_multi_options
 
 from pylama.lint import Linter as Abstract
 
@@ -24,9 +24,13 @@ class Linter(Abstract):
         for option in parser.option_list:
             if option.dest and option.dest in params:
                 value = params[option.dest]
-                if not isinstance(value, str):
-                    continue
-                params[option.dest] = option.convert_value(option, params[option.dest])
+                if isinstance(value, str):
+                    params[option.dest] = option.convert_value(option, value)
+
+        for key in ["filename", "exclude", "select", "ignore"]:
+            if key in params and isinstance(params[key], str):
+                params[key] = _parse_multi_options(params[key])
+
         P8Style = StyleGuide(reporter=_PycodestyleReport, **params)
         buf = StringIO(code)
         return P8Style.input_file(path, lines=buf.readlines())

--- a/test_pylama.py
+++ b/test_pylama.py
@@ -114,7 +114,7 @@ def test_ignore_select():
     options.ignore = ['E301', 'D102']
     options.linters = ['pycodestyle', 'pydocstyle', 'pyflakes', 'mccabe']
     errors = run('dummy.py', options=options)
-    assert len(errors) == 17
+    assert len(errors) == 29
 
     options.ignore = ['E3', 'D']
     errors = run('dummy.py', options=options)


### PR DESCRIPTION
This correctly parses options of the form "E302,W405", which before this was split into individual characters. This resulted in all errors and/or being considered when ignoring/selecting.

Since specifying just "E" disables all errors, having a list of characters meant that it always encountered an individual "E" and thus disabled all errors.