### PR TITLE
Fix Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: python
 
-python:
-    - "2.7"
-
-env:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py35
-    - TOXENV=cov
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=cov
+      after_script:
+        - pip install coveralls;
+        - coveralls;
 
 branches:
     only:
@@ -17,9 +22,3 @@ branches:
 install: pip install tox
 
 script: tox
-
-after_script:
-    - if [ $TOXENV == "cov" ]; then
-        pip install coveralls;
-        coveralls;
-      fi


### PR DESCRIPTION
You can't rely on tox alone to test the various versions of python because they might not be installed. Instead specify a build matrix by hand. This also allows for a cleaner after_script for coveralls.