### PR TITLE
Respect tools own config without pylama: prefix

### DIFF
--- a/pylama/config.py
+++ b/pylama/config.py
@@ -178,10 +178,11 @@ def parse_options(args=None, config=True, rootdir=CURDIR, **overrides): # noqa
         # Parse file related options
         for name, opts in cfg.sections.items():
 
-            if not name.startswith('pylama') or name == cfg.default_section:
+            if name == cfg.default_section:
                 continue
 
-            name = name[7:]
+            if name.startswith('pylama'):
+                name = name[7:]
 
             if name in LINTERS:
                 options.linters_params[name] = dict(opts)


### PR DESCRIPTION
This allows running each tool separately _and_ all using pylama.
Currently you need to duplicate the configs, which makes it much more
painful then it needs to be.

Fixes #69