### PR TITLE
Update README.rst for instructions on running from python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -332,10 +332,23 @@ Run pylama from python code
 
     from pylama.main import check_path, parse_options
 
-    my_redefined_options = {...}
+    # Use and/or modify 0 or more of the options defined as keys in the variable my_redefined_options below.
+    # To use defaults for any option, remove that key completely.
+    my_redefined_options = {
+        'linters': ['pep257', 'pydocstyle', 'pycodestyle', 'pyflakes' ...],
+        'ignore': ['D203', 'D213', 'D406', 'D407', 'D413' ...],
+        'select': ['R1705' ...],
+        'sort': 'F,E,W,C,D,...',
+        'skip': '*__init__.py,*/test/*.py,...',
+        'async': True,
+        'force': True
+        ...
+    }
+    # relative path of the directory in which pylama should check
     my_path = '...'
+
     options = parse_options([my_path], **my_redefined_options)
-    errors = check_path(options)
+    errors = check_path(options, rootdir='.')
 
 
 .. _bagtracker:


### PR DESCRIPTION
* Added the subset of the CLI options when running pylama from python. CLI options like report, abspath and format cannot be used. Also, some of the usable options work as lists while others work as comma separated strings.

* Added the rootdir parameter to check_path() call. Without this parameter, the python code is unable to get the relative paths of files to be audited and results in the following error.

    `"[Errno 2] No such file or directory: '<filepath>.py' [undefined]"`