### PR TITLE
Fix AttributeError: 'list' object has no attribute 'split'

### DIFF
--- a/pylama/core.py
+++ b/pylama/core.py
@@ -62,11 +62,11 @@ def run(path='', code=None, rootdir=CURDIR, options=None):
 
                 ignore = params.get('ignore', set())
                 if 'ignore' in lparams:
-                    ignore |= set(lparams['ignore'].split(','))
+                    ignore |= set(lparams['ignore'])
 
                 select = params.get('select', set())
                 if 'select' in lparams:
-                    select |= set(lparams['select'].split(','))
+                    select |= set(lparams['select'])
 
                 linter_errors = linter.run(
                     path, code=code, ignore=ignore, select=select, params=lparams)

--- a/test_pylama.py
+++ b/test_pylama.py
@@ -137,6 +137,10 @@ def test_ignore_select():
     assert 'E301' not in numbers
     assert 'D102' not in numbers
 
+    options.linters_params['pycodestyle']['ignore'] = ['E126']
+    errors = run('dummy.py', options=options)
+    assert numbers == [error.number for error in errors]
+
     options.ignore = ['E3', 'D', 'E2']
     errors = run('dummy.py', options=options)
     assert len(errors) == 0


### PR DESCRIPTION
`pylama` failed with following errors in `pylama 7.6.5` + `Python 3.7`/`3.6`.
This PR fix these errors.

```
$ pylama
Traceback (most recent call last):
  File "/home/toor/.pyenv/versions/3.7.0/lib/python3.7/site-packages/pylama/core.py", line 65, in run
    ignore |= set(lparams['ignore'].split(','))
AttributeError: 'list' object has no attribute 'split'

Traceback (most recent call last):
  File "/home/toor/.pyenv/versions/3.7.0/lib/python3.7/site-packages/pylama/core.py", line 65, in run
    ignore |= set(lparams['ignore'].split(','))
AttributeError: 'list' object has no attribute 'split'
a
...
```

I had used a pylama.ini file like the below:

```
[pylama:pycodestyle]
max_line_length = 100
ignore = E203,W503
```

Looks like `split` method call in https://github.com/klen/pylama/blob/develop/pylama/core.py#L65 is not needed. When reaching the L65, `lparams['ignore']` already parsed and the data type is a `list` as follows:

    {'max_line_length': 100, 'ignore': ['E203', 'W503']}

https://github.com/klen/pylama/blob/develop/pylama/core.py#L69
also has the same problem.
