### PR TITLE
Avoid reference usage for linter specific ignore/select

### DIFF
--- a/pylama/core.py
+++ b/pylama/core.py
@@ -60,11 +60,11 @@ def run(path='', code=None, rootdir=CURDIR, options=None):
                 lparams = linters_params.get(lname, dict())
                 LOGGER.info("Run %s %s", lname, lparams)
 
-                ignore = params.get('ignore', set())
+                ignore = set(params.get('ignore', set()))
                 if 'ignore' in lparams:
                     ignore |= set(lparams['ignore'].split(','))
 
-                select = params.get('select', set())
+                select = set(params.get('select', set()))
                 if 'select' in lparams:
                     select |= set(lparams['select'].split(','))
 


### PR DESCRIPTION
https://github.com/klen/pylama/blob/develop/pylama/core.py#L63

```py
ignore = params.get('ignore', set())
```

In the above line, using `params` reference as it is, so if reaching L65, params will be overwritten, and previous linter specific settings will affect  in the next linter iterations.

```py
ignore |= set(lparams['ignore'].split(','))
```

This issue can be avoided by defensive copy.

L67 `select` has the same issue.