### PR TITLE
Added eradicate as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mccabe      >= 0.5.2
 pycodestyle >= 2.3.1
 pydocstyle  >= 2.0.0
 pyflakes    >= 1.5.0
+eradicate   >= 1.0.0


### PR DESCRIPTION
Added eradicate to the requirements.txt file.

This will prevent the ``WARNING:root:Linter eradicate not found`` error.