### PR TITLE
Fix error number handling for ignore/select of eradicate

### DIFF
--- a/pylama/lint/pylama_eradicate.py
+++ b/pylama/lint/pylama_eradicate.py
@@ -29,7 +29,7 @@ class Linter(Abstract):
                 lnum=line_number,
                 offset=len(line) - len(line.rstrip()),
                 # https://github.com/sobolevn/flake8-eradicate#output-example
-                text=converter('E800: Found commented out code: ') + line,
+                text=converter('E800 Found commented out code: ') + line,
                 # https://github.com/sobolevn/flake8-eradicate#error-codes
                 type='E800',
             ))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,16 +26,16 @@ def test_config():
 def test_ignore_select():
     options = parse_options()
     options.ignore = ['E301', 'D102']
-    options.linters = ['pycodestyle', 'pydocstyle', 'pyflakes', 'mccabe']
+    options.linters = ['pycodestyle', 'pydocstyle', 'pyflakes', 'mccabe', 'eradicate']
     errors = run('dummy.py', options=options)
-    assert len(errors) == 31
+    assert len(errors) == 35
 
     numbers = [error.number for error in errors]
     assert 'D100' in numbers
     assert 'E301' not in numbers
     assert 'D102' not in numbers
 
-    options.ignore = ['E3', 'D', 'E2']
+    options.ignore = ['E3', 'D', 'E2', 'E8']
     errors = run('dummy.py', options=options)
     assert not errors
 


### PR DESCRIPTION
The text of errors from eradicate currently begins with "E800: ", which prevents the error number from being parsed by [`Error`](https://github.com/klen/pylama/blob/7.6.6/pylama/errors.py#L93) and makes it impossible to ignore `E800`.  This pull request removes the colon, to fix the problem and match the style of the other linters.  It also adds `E8` to `test_ignore_select` in `test_config` to cover this.

Thanks for considering,
Kevin