### PR TITLE
Fixed 2 issues of type: PYTHON_E402 throughout 2 files in repo.

### DIFF
--- a/pylama/lint/extensions.py
+++ b/pylama/lint/extensions.py
@@ -1,3 +1,4 @@
+from pkg_resources import iter_entry_points
 """Load extensions."""
 
 LINTERS = {}
@@ -53,7 +54,6 @@ except ImportError:
     pass
 
 
-from pkg_resources import iter_entry_points
 
 for entry in iter_entry_points('pylama.linter'):
     if entry.name not in LINTERS:

--- a/pylama/lint/pylama_pydocstyle.py
+++ b/pylama/lint/pylama_pydocstyle.py
@@ -1,3 +1,4 @@
+from pylama.lint import Linter as Abstract
 """pydocstyle support."""
 
 THIRD_ARG = True
@@ -9,7 +10,6 @@ except ImportError:
     from pydocstyle import PEP257Checker as PyDocChecker
     THIRD_ARG = False
 
-from pylama.lint import Linter as Abstract
 
 
 class Linter(Abstract):


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.