### PR TITLE
Added convention option support to pydocstyle

### DIFF
--- a/pylama/lint/pylama_pydocstyle.py
+++ b/pylama/lint/pylama_pydocstyle.py
@@ -4,9 +4,11 @@ THIRD_ARG = True
 try:
     #: Import for pydocstyle 2.0.0 and newer
     from pydocstyle import ConventionChecker as PyDocChecker
+    from pydocstyle.violations import conventions
 except ImportError:
     #: Backward compatibility for pydocstyle prior to 2.0.0
     from pydocstyle import PEP257Checker as PyDocChecker
+    conventions = ()
     THIRD_ARG = False
 
 from pylama.lint import Linter as Abstract
@@ -26,6 +28,10 @@ class Linter(Abstract):
             ignore_decorators = params['ignore_decorators']
         else:
             ignore_decorators = None
+        if 'convention' in params:
+            convention_codes = conventions.get(params['convention'], None)
+        else:
+            convention_codes = None
         check_source_args = (code, path, ignore_decorators) if THIRD_ARG else (code, path)
         return [{
             'lnum': e.line,
@@ -34,4 +40,5 @@ class Linter(Abstract):
                      if e.message[4] == ':' else e.message),
             'type': 'D',
             'number': e.code
-        } for e in PyDocChecker().check_source(*check_source_args)]
+        } for e in PyDocChecker().check_source(*check_source_args)
+            if convention_codes is None or getattr(e, 'code', None) in convention_codes]


### PR DESCRIPTION
Implemented the `convention` option that lets the user select their preferred documentation style (pep257, numpy, google).

It's been done in a similar way to how pydocstyle does internally: filtering the errors using a preset for that convention.