### PR TITLE
feat: add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: pylama
+  name: pylama
+  description: "Code audit tool for Python and JavaScript"
+  entry: pylama
+  language: python
+  language_version: python3
+  minimum_pre_commit_version: 2.9.2
+  types: [python, pyi]


### PR DESCRIPTION
Adds a precommit hook for pylama to allow for easy integration into pre-commit tooling.


Builds off of: https://github.com/gvanderest/pylama-pre-commit but felt like it should be native in the repo itself instead of a 3rd party maintaining it.