### PR TITLE
fix setup.py to only include main source tree

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ meta = dict(
     author_email='horneds@gmail.com',
     url=' https://github.com/klen/pylama',
 
-    packages=find_packages(exclude=['plugins']),
+    packages=find_packages(include=['pylama.*'], exclude=['plugins']),
 
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ meta = dict(
     author_email='horneds@gmail.com',
     url=' https://github.com/klen/pylama',
 
-    packages=find_packages(include=['pylama.*'], exclude=['plugins']),
+    packages=find_packages(include=['pylama*']),
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
The current setup.py file is including all directories with python files. So when installing via `pip install pylama` not only `pylama` directory is created in `site-packages` - also `tests` will be added.

This can be fixed by only including the correct source tree.