### PR TITLE
Fix breaking change in pylint 2.8.0

### DIFF
--- a/pylama/lint/pylama_pylint.py
+++ b/pylama/lint/pylama_pylint.py
@@ -4,7 +4,11 @@ from os import path as op, environ
 
 from astroid import MANAGER
 from pylama.lint import Linter as BaseLinter
-from pylint.__pkginfo__ import numversion
+try:
+    from pylint.__pkginfo__ import numversion
+except ImportError:
+    # There was a breaking change in pylint 2.8.0
+    numversion = (2, 8, 0)
 from pylint.lint import Run
 from pylint.reporters import BaseReporter
 


### PR DESCRIPTION
The test on numversion does not check anything on the 8 or the 0 so hardcoding it is okay right now.

Closes https://github.com/PyCQA/pylint/issues/4399