### PR TITLE
Fix long_description type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ meta = dict(
     license=_license,
     description=_read('DESCRIPTION'),
     long_description=_read('README.rst'),
+    long_description_content_type='text/x-rst',
+
     platforms=('Any'),
     zip_safe=False,
     keywords='pylint pep8 pycodestyle pyflakes mccabe linter qa pep257 pydocstyle'.split(),


### PR DESCRIPTION
# Specifies the type of the long_description [in setuptools.setup](https://setuptools.readthedocs.io/en/latest/references/keywords.html#:~:text=long_description_content_type)

## This will basically change the PyPI page from looking like this:

![image_example_before](https://i.imgur.com/oJ2UHRI.png)

## to this:

![image_example_after](https://i.imgur.com/QFGyaIM.png)