### PR TITLE
Fix `RunContext.get_params` for `ignore` and `select` linter params

### DIFF
--- a/pylama/context.py
+++ b/pylama/context.py
@@ -156,7 +156,7 @@ class RunContext:  # pylint: disable=R0902
         """Get params for a linter with the given name."""
         lparams = self.linters_params.get(name, {})
         for key in ("ignore", "select"):
-            if key in lparams:
+            if key in lparams and not isinstance(lparams[key], set):
                 lparams[key] = set(lparams[key].split(","))
         return lparams
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -36,3 +36,17 @@ def test_filter(parse_args, context):
     ctx.push(number='E300', source='pydocstyle')
     assert ctx.errors
     assert len(ctx.errors) == 2
+
+
+def test_get_params_doesnt_fail_on_subsequent_invocation(context):
+    linter_params ={
+        "pycodestyle": {
+            "ignore": "D203,W503"
+        }
+    }
+
+    ctx = context(**linter_params)
+    ctx.get_params("pycodestyle")
+
+    ctx = context(**linter_params)
+    ctx.get_params("pycodestyle")


### PR DESCRIPTION
For `ignore` and `select` linter params `RunContext.get_params`
transforms parameter value which is comma separated string to set of
values by splitting that string. Subsequent calls to `get_params` (in
case of cache miss or if another instance of `RunContext` is used) tries
to perform this transformation again and fails because `set` doesn't
have split method.

This commit adds additional check before converting CSV string into a
set -- if the value is already a set, we skip this transformation.