### PR TITLE
`RunContext` swallows unexpected exceptions silently

### DIFF
--- a/pylama/context.py
+++ b/pylama/context.py
@@ -89,19 +89,23 @@ class RunContext:  # pylint: disable=R0902
         if self._tempfile is not None:
             remove(self._tempfile)
 
+        suppress_exception = False
         if evalue is not None:
             if etype is IOError:
                 self.push(text=f"E001 {evalue}", number="E001")
+                suppress_exception = True
             elif etype is UnicodeDecodeError:
                 self.push(text=f"E001 UnicodeError: {self.filename}", number="E001")
+                suppress_exception = True
             elif etype is SyntaxError:
                 self.push(
                     lnum=evalue.lineno,
                     col=evalue.offset,
                     text=f"E0100 SyntaxError: {evalue.args[0]}",
                 )
+                suppress_exception = True
 
-        return self
+        return suppress_exception
 
     @property
     def source(self):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_modeline(context):
     ctx = context(code=(
         "def test():\n"
@@ -36,3 +39,11 @@ def test_filter(parse_args, context):
     ctx.push(number='E300', source='pydocstyle')
     assert ctx.errors
     assert len(ctx.errors) == 2
+
+
+def test_context_doesnt_suppress_exception(context):
+    ctx = context()
+
+    with pytest.raises(Exception):
+        with ctx:
+            raise Exception()


### PR DESCRIPTION
If Context Manager's method `__exit__` returns a true value exception
thrown in `with` block is not propagated. Currently
`RunContext.__exit__` return `self` which is always a true value because
it can never be `None`.

This change fixes `__exit__` method to return `True` only if exception
is expected (i.e. handled by pushing error message into the context). In
other cases exception will always be propagated.