### PR TITLE
Fix `RunContext` modifies passed in options object

### DIFF
--- a/pylama/context.py
+++ b/pylama/context.py
@@ -47,7 +47,7 @@ class RunContext:  # pylint: disable=R0902
         self.skip = False
         self.ignore = set()
         self.select = set()
-        self.linters = None
+        self.linters = []
         self.linters_params = {}
 
         self._ast = None
@@ -62,10 +62,10 @@ class RunContext:  # pylint: disable=R0902
             self.skip = options.skip and any(
                 ptrn.match(filename) for ptrn in options.skip
             )
-            self.linters = options.linters
-            self.ignore = options.ignore
-            self.select = options.select
-            self.linters_params = options.linters_params
+            self.linters.extend(options.linters)
+            self.ignore |= options.ignore
+            self.select |= options.select
+            self.linters_params.update(options.linters_params)
 
             for mask in options.file_params:
                 if mask.match(filename):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -56,7 +56,7 @@ def test_get_params_doesnt_fail_on_subsequent_invocation(context):
 
 
 def test_context_linters_params(context):
-    params = {'pylint': {'good_names': 'f'}}
+    params = {"pylint": {"good_names": "f"}}
     ctx = context(**params)
     lparams = ctx.get_params("pylint")
     assert lparams
@@ -67,3 +67,18 @@ def test_context_linters_params(context):
     lparams = ctx.get_params("pylint")
     assert lparams
     assert "enable" not in lparams
+
+
+def test_context_does_not_change_global_options(context, parse_args):
+    """Ensure a RunContext does not change the passed in options object."""
+    options = parse_args(" --select=W123 --ignore=W234 --linters=pylint dummy.py")
+    ctx = context(options=options)
+    ctx.update_params(linters="pycodestyle", select="W345", ignore="W678")
+
+    assert ctx.linters is not options.linters
+    assert ctx.select is not options.select
+    assert ctx.ignore is not options.ignore
+
+    assert options.linters == ["pylint"]
+    assert options.select == {"W123"}
+    assert options.ignore == {"W234"}


### PR DESCRIPTION
Currently the `RunContext` constructor assigns attributes of the passed in `argparse.Namespace` to itself directly. As a result, when `RunContext.update_params` makes changes, those also persist in the `argparse.Namespace`. In particular this was seen breaking modeline support in #209 where an `ignore` is added via modeline for one file and then persists in all subsequent files.

This changes the `RunContext` constructor to update the object-local containers instead of assigning directly.