### PR TITLE
Fix crash in case of empty file in directory

### DIFF
--- a/pylama/context.py
+++ b/pylama/context.py
@@ -181,8 +181,10 @@ class RunContext:  # pylint: disable=R0902
         err = Error(filename=self.filename, **params)
         number = err.number
 
-        if SKIP_PATTERN(self.lines[err.lnum - 1]):
-            return None
+        if bool(len(self.lines)):
+
+            if SKIP_PATTERN(self.lines[err.lnum - 1 ]):
+                return None
 
         if filtrate:
 


### PR DESCRIPTION
I have added a simple check for the issue #214, that skips the regex check SKIP_PATTERN when there are no lines to analyze.

I think that the fact that there is an empty file in the directory should be flagged as en error, but i would like to hear your opinion first before working on it. 

Thanks for your work :) 