### PR TITLE
Add optional TOML configuration support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,10 @@ Installation:
 
     $ pip install pylama
 
+TOML configuration can be enabled optionally: ::
+
+    $ pip install pylama[toml]
+
 You may optionally install the requirements with the library: ::
 
     $ pip install pylama[mypy]
@@ -199,24 +203,28 @@ Just add ``# noqa`` at the end of a line to ignore:
 .. _config:
 
 Configuration file
-------------------
+==================
 
 **Pylama** looks for a configuration file in the current directory.
 
 You can use a “global” configuration, stored in `.pylama.ini` in your home
 directory. This will be used as a fallback configuration.
 
-The program searches for the first matching ini-style configuration file in
-the directories of command line argument. Pylama looks for the configuration
-in this order: ::
+The program searches for the first matching configuration file in the
+directories of command line argument. Pylama looks for the configuration in
+this order: ::
 
     ./pylama.ini
+    ./pyproject.toml
     ./setup.cfg
     ./tox.ini
     ./pytest.ini
     ~/.pylama.ini
 
 The ``--option`` / ``-o`` argument can be used to specify a configuration file.
+
+INI-style configuration
+-----------------------
 
 Pylama searches for sections whose names start with `pylama`.
 
@@ -231,7 +239,7 @@ The `pylama` section configures global options like `linters` and `skip`.
     ignore = F0401,C0111,E731
 
 Set code-checkers' options
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can set options for a special code checkers with pylama configurations.
 
@@ -253,7 +261,7 @@ replaced by underscores (e.g. Pylint's ``max-line-length`` becomes
 
 
 Set options for file (group of files)
--------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can set options for special file (group of files)
 with sections:
@@ -270,6 +278,66 @@ The options have a higher priority than in the `pylama` section.
     ignore = C0110
 
     [pylama:*/setup.py]
+    skip = 1
+
+TOML configuration
+-----------------------
+
+Pylama searches for sections whose names start with `tool.pylama`.
+
+The `tool.pylama` section configures global options like `linters` and `skip`.
+
+::
+
+    [tool.pylama]
+    format = "pylint"
+    skip = "*/.tox/*,*/.env/*"
+    linters = "pylint,mccabe"
+    ignore = "F0401,C0111,E731"
+
+Set code-checkers' options
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can set options for a special code checkers with pylama configurations.
+
+::
+
+    [tool.pylama.linter.pyflakes]
+    builtins = "_"
+
+    [tool.pylama.linter.pycodestyle]
+    max_line_length = 100
+
+    [tool.pylama.linter.pylint]
+    max_line_length = 100
+    disable = "R"
+
+See code-checkers' documentation for more info. Note that dashes are
+replaced by underscores (e.g. Pylint's ``max-line-length`` becomes
+``max_line_length``).
+
+
+Set options for file (group of files)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can set options for special file (group of files)
+with sections:
+
+The options have a higher priority than in the `tool.pylama` section.
+
+::
+
+    [[tool.pylama.files]]
+    path = "*/pylama/main.py"
+    ignore = "C901,R0914,W0212"
+    select = "R"
+
+    [[tool.pylama.files]]
+    path = "pylama:*/tests.py"
+    ignore = "C0110"
+
+    [[tool.pylama.files]]
+    path = "pylama:*/setup.py"
     skip = 1
 
 

--- a/pylama/config_toml.py
+++ b/pylama/config_toml.py
@@ -1,0 +1,31 @@
+"""Pylama TOML configuration."""
+
+import toml
+
+from pylama.libs.inirama import Namespace as _Namespace
+
+
+class Namespace(_Namespace):
+    """Inirama-style wrapper for TOML config."""
+
+    def parse(self, source: str, update: bool = True, **params):
+        """Parse TOML source as string."""
+        content = toml.loads(source)
+        tool = content.get("tool", {})
+        pylama = tool.get("pylama", {})
+        linters = pylama.pop("linter", {})
+        files = pylama.pop("files", [])
+
+        for name, value in pylama.items():
+            self["pylama"][name] = value
+
+        for linter, options in linters.items():
+            for name, value in options.items():
+                self[f"pylama:{linter}"][name] = value
+
+        for file in files:
+            path = file.pop("path", None)
+            if path is None:
+                continue
+            for name, value in file.items():
+                self[f"pylama:{path}"][name] = value

--- a/pylama/core.py
+++ b/pylama/core.py
@@ -48,7 +48,7 @@ def run(
     sorter = default_sorter
     if options and options.sort:
         sort = options.sort
-        sorter = lambda err: (sort.get(err.etype, 999), err.lnum)
+        sorter = lambda err: (sort.get(err.etype, 999), err.lnum)  # pylint: disable=C3001
 
     return sorted(errors, key=sorter)
 

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -5,6 +5,8 @@ radon       >= 5.1.0
 mypy
 pylint      >= 2.11.1
 pylama-quotes
+toml
 vulture
 
 types-setuptools
+types-toml

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ max_line_length = 100
 builtins = _
 
 [pylama:pylint]
-ignore=R,E1002,W0511,C0103,C0204
+ignore=R,E1002,W0511,C0103,C0204,W0012
 
 [pylama:pylama/core.py]
 ignore = C901,R0914

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=parse_requirements("requirements/requirements.txt"),
     extras_require=dict(
         tests=parse_requirements("requirements/requirements-tests.txt"),
-        all=OPTIONAL_LINTERS, **{linter: [linter] for linter in OPTIONAL_LINTERS}
+        all=OPTIONAL_LINTERS, **{linter: [linter] for linter in OPTIONAL_LINTERS},
+        toml="toml>=0.10.2",
     ),
 )

--- a/tests/test_config_toml.py
+++ b/tests/test_config_toml.py
@@ -1,0 +1,74 @@
+"""Test TOML config handling."""
+
+from unittest import mock
+
+from pylama import config_toml
+from pylama.config import DEFAULT_SECTION
+from pylama.libs import inirama
+
+CONFIG_TOML = """
+[tool.pylama]
+async = 1
+ignore = "D203,D213,F0401,C0111,E731,I0011"
+linters = "pycodestyle,pyflakes,mccabe,pydocstyle,pylint,mypy"
+skip = "pylama/inirama.py,pylama/libs/*"
+verbose = 0
+max_line_length = 100
+
+[tool.pylama.linter.pyflakes]
+builtins = "_"
+
+[tool.pylama.linter.pylint]
+ignore = "R,E1002,W0511,C0103,C0204"
+
+[[tool.pylama.files]]
+path = "pylama/core.py"
+ignore = "C901,R0914"
+
+[[tool.pylama.files]]
+path = "pylama/main.py"
+ignore = "R0914,W0212,C901,E1103"
+
+[[tool.pylama.files]]
+path = "tests/*"
+ignore = "D,C,W,E1103"
+"""
+
+CONFIG_INI="""
+[pylama]
+async = 1
+ignore = D203,D213,F0401,C0111,E731,I0011
+linters = pycodestyle,pyflakes,mccabe,pydocstyle,pylint,mypy
+skip = pylama/inirama.py,pylama/libs/*
+verbose = 0
+max_line_length = 100
+
+[pylama:pyflakes]
+builtins = _
+
+[pylama:pylint]
+ignore=R,E1002,W0511,C0103,C0204
+
+[pylama:pylama/core.py]
+ignore = C901,R0914
+
+[pylama:pylama/main.py]
+ignore = R0914,W0212,C901,E1103
+
+[pylama:tests/*]
+ignore = D,C,W,E1103
+"""
+
+def test_toml_parsing_matches_ini():
+    """Ensure the parsed TOML namepsace matches INI parsing."""
+    with mock.patch("pylama.libs.inirama.io.open", mock.mock_open(read_data=CONFIG_INI)):
+        ini = inirama.Namespace()
+        ini.default_section = DEFAULT_SECTION
+        ini.read("ini")
+
+    with mock.patch("pylama.libs.inirama.io.open", mock.mock_open(read_data=CONFIG_TOML)):
+        toml = config_toml.Namespace()
+        toml.default_section = DEFAULT_SECTION
+        toml.read("toml")
+
+    assert ini.sections == toml.sections


### PR DESCRIPTION
Adds support for TOML configuration files, in particular pyproject.toml inside a `[tool.pylama]` section.

This seemed like the least intrusive way to add support. Reuses the existing vendored inirama with a simple shim to parse TOML tables. The resulting objectis still just a `inirama.Namespace` so no usage changes are needed. All behind a `toml` extras for anyone who doesn't want to pull in the added dependency.

Needed a couple pylint config changes for tests to pass on current pylint version 2.14.4:
* Disable W0012/unknown-option value
* Disable C3001/unnecessary-lambda-assignment in core.py