### PR TITLE
Fix to adapt to messages removed at pyflakes 2.5.0

### DIFF
--- a/pylama/lint/pylama_pyflakes.py
+++ b/pylama/lint/pylama_pyflakes.py
@@ -9,7 +9,6 @@ m = checker.messages
 CODES = {
     m.UnusedImport.message: "W0611",
     m.RedefinedWhileUnused.message: "W0404",
-    m.RedefinedInListComp.message: "W0621",
     m.ImportShadowedByLoopVar.message: "W0621",
     m.ImportStarUsed.message: "W0401",
     m.ImportStarUsage.message: "W0401",
@@ -20,7 +19,6 @@ CODES = {
     m.DuplicateArgument.message: "E1122",
     m.LateFutureImport.message: "W0410",
     m.UnusedVariable.message: "W0612",
-    m.ReturnWithArgsInsideGenerator.message: "E0106",
     m.ReturnOutsideFunction.message: "E0104",
 }
 

--- a/pylama/lint/pylama_pyflakes.py
+++ b/pylama/lint/pylama_pyflakes.py
@@ -22,6 +22,13 @@ CODES = {
     m.ReturnOutsideFunction.message: "E0104",
 }
 
+# RedefinedInListComp and ReturnWithArgsInsideGenerator were removed at pyflakes 2.5.0:
+#   https://github.com/PyCQA/pyflakes/commit/2246217295dc8cb30ef4a7b9d8dc449ce32e603a
+if hasattr(m, "RedefinedInListComp"):
+    CODES[m.RedefinedInListComp.message] = "W0621"
+if hasattr(m, "ReturnWithArgsInsideGenerator"):
+    CODES[m.ReturnWithArgsInsideGenerator.message] = "E0106"
+
 
 class Linter(Abstract):
     """Pyflakes runner."""


### PR DESCRIPTION
Fix #224

`RedefinedInListComp` and `ReturnWithArgsInsideGenerator` were removed at `pyflakes 2.5.0`:
https://github.com/PyCQA/pyflakes/commit/2246217295dc8cb30ef4a7b9d8dc449ce32e603a
