### PR TITLE
Use tomli/tomllib instead of the unmaintained toml package

### DIFF
--- a/pylama/config_toml.py
+++ b/pylama/config_toml.py
@@ -1,8 +1,13 @@
 """Pylama TOML configuration."""
 
-import toml
+import sys
 
 from pylama.libs.inirama import Namespace as _Namespace
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 class Namespace(_Namespace):
@@ -10,7 +15,7 @@ class Namespace(_Namespace):
 
     def parse(self, source: str, update: bool = True, **params):
         """Parse TOML source as string."""
-        content = toml.loads(source)
+        content = tomllib.loads(source)
         tool = content.get("tool", {})
         pylama = tool.get("pylama", {})
         linters = pylama.pop("linter", {})

--- a/requirements/requirements-tests.txt
+++ b/requirements/requirements-tests.txt
@@ -5,8 +5,7 @@ radon       >= 5.1.0
 mypy
 pylint      >= 2.11.1
 pylama-quotes
-toml
+tomli       >= 1.2.3  ; python_version < "3.11"
 vulture
 
 types-setuptools
-types-toml

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setup(
     extras_require=dict(
         tests=parse_requirements("requirements/requirements-tests.txt"),
         all=OPTIONAL_LINTERS, **{linter: [linter] for linter in OPTIONAL_LINTERS},
-        toml="toml>=0.10.2",
+        toml="tomli>=1.2.3; python_version < '3.11'",
     ),
 )


### PR DESCRIPTION
Replace the use of the unmaintained `toml` package with the modern alternatives: the built-in `tomllib` in Python 3.11+, and its equivalent `tomli` in older Python versions.  `tomli` installs type stubs, so there is no need for an additional `types-*` package for it.