### PR TITLE
fix: pydocstyle ignore parameters

### DIFF
--- a/pylama/lint/pylama_pydocstyle.py
+++ b/pylama/lint/pylama_pydocstyle.py
@@ -1,6 +1,7 @@
 """pydocstyle support."""
 
 from argparse import ArgumentParser
+from re import compile
 
 from pydocstyle import ConventionChecker as PyDocChecker
 from pydocstyle.violations import conventions
@@ -30,10 +31,11 @@ class Linter(Abstract):
         if options and options.pydocstyle_convention:
             params.setdefault("convention", options.pydocstyle_convention)
         convention_codes = conventions.get(params.get("convention"))
+        ignore_decorators_param = params.get("ignore_decorators")
         for err in PyDocChecker().check_source(
             ctx.source,
             ctx.filename,
-            params.get("ignore_decorators"),
+            compile(ignore_decorators_param) if ignore_decorators_param is not None else None,
             params.get("ignore_inline_noqa", False),
         ):
             if convention_codes is None or err.code in convention_codes:


### PR DESCRIPTION
The pydocstyle "ignore_decorators" configuration throws an error because we pass a string to pydocstyle's ConventionChecker.check_source() when it expects a regular expression object.