### PR TITLE
Fixes to work with Python 3.12+

### DIFF
--- a/pylama/lint/__init__.py
+++ b/pylama/lint/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pkgutil import walk_packages
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
-from pkg_resources import iter_entry_points
+from importlib_metadata import entry_points
 
 LINTERS: Dict[str, Type[LinterV2]] = {}
 
@@ -58,7 +58,7 @@ for _, pname, _ in walk_packages([str(Path(__file__).parent)]):  # type: ignore
         pass
 
 # Import installed linters
-for entry in iter_entry_points("pylama.linter"):
+for entry in entry_points(group="pylama.linter"):
     if entry.name not in LINTERS:
         try:
             LINTERS[entry.name] = entry.load()

--- a/pylama/lint/__init__.py
+++ b/pylama/lint/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pkgutil import walk_packages
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
-from importlib_metadata import entry_points
+from importlib.metadata import entry_points
 
 LINTERS: Dict[str, Type[LinterV2]] = {}
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,3 +4,4 @@ mccabe      >= 0.7.0
 pycodestyle >= 2.9.1
 pydocstyle  >= 6.1.1
 pyflakes    >= 2.5.0
+setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,16 +24,15 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Quality Assurance
     Topic :: Software Development :: Testing
 
 [options]
 packages = pylama
-python_requires = >= 3.7
+python_requires = >= 3.8
 include_package_data = True
 
 [options.package_data]

--- a/setup.py
+++ b/setup.py
@@ -4,22 +4,32 @@
 
 import pathlib
 
-import pkg_resources
 from setuptools import setup
-
-
-def parse_requirements(path: str) -> "list[str]":
-    with pathlib.Path(path).open(encoding='utf-8') as requirements:
-        return [str(req) for req in pkg_resources.parse_requirements(requirements)]
-
 
 OPTIONAL_LINTERS = ['pylint', 'eradicate', 'radon', 'mypy', 'vulture']
 
 
 setup(
-    install_requires=parse_requirements("requirements/requirements.txt"),
+    install_requires=[
+        'mccabe>=0.7.0',
+        'pycodestyle>=2.9.1',
+        'pydocstyle>=6.1.1',
+        'pyflakes>=2.5.0'
+    ],
     extras_require=dict(
-        tests=parse_requirements("requirements/requirements-tests.txt"),
+        tests=[
+            'pytest>=7.1.2',
+            'pytest-mypy',
+            'eradicate>=2.0.0',
+            'radon>=5.1.0',
+            'mypy',
+            'pylint>=2.11.1',
+            'pylama-quotes',
+            'toml',
+            'vulture',
+            'types-setuptools',
+            'types-toml'
+        ],
         all=OPTIONAL_LINTERS, **{linter: [linter] for linter in OPTIONAL_LINTERS},
         toml="toml>=0.10.2",
     ),


### PR DESCRIPTION
This patch removes the dependence on `pkg_resources` which is not available by default in Python 3.12 and beyond. It switches from `pkg_resources.iter_entry_points` to `import_metadata.entry_points`. `import_metadata` is available in all supported versions of Python.

The other change removes the use of `parse_requirements` and just hardcodes the package dependencies in `setup.py`, which is arguably good practice anyway since not all developer-installed packages are required by the installation.

Finally, `setuptools` is added to `requirements.txt` since it is also no longer installed by default with Python 3.12.